### PR TITLE
Matching and reporting of target pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,16 @@ jobs:
         name: Install dependencies
         command: |
           sudo env GOOS=darwin GOARCH=amd64 $(which go) install std
+          go get golang.org/x/tools/cmd/goimports
           wget -O /tmp/upx.tar.xz https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_linux.tar.xz
           tar --strip=1 -C /tmp -xf /tmp/upx.tar.xz
           sudo install /tmp/upx /usr/bin/upx
     - run:
         name: Run tests
         command: |
-          gofmt -l -s -w .
+          gofmt -l -s -w $(find . -name '*.go' | grep -v /vendor/)
+          goimports -l -w $(find . -name '*.go' | grep -v /vendor/)
+          go test -race -v ./...
     - run:
         name: Build binary
         command: CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -ldflags="-s -w" -o build/chromatic .

--- a/chromatic/config.go
+++ b/chromatic/config.go
@@ -19,10 +19,16 @@ type startConfig struct {
 }
 
 type endConfig struct {
-	URL     string `yaml:"url"`
-	Title   string `yaml:"title"`
-	Cookie  string `yaml:"cookie"`
-	Timeout int64  `yaml:"timeout"`
+	URL     string       `yaml:"url"`
+	Title   string       `yaml:"title"`
+	Cookie  cookieConfig `yaml:"cookie"`
+	Timeout int64        `yaml:"timeout"`
+}
+
+type cookieConfig struct {
+	Name   string `yaml:"name" json:"name"`
+	Domain string `yaml:"domain" json:"domain"`
+	Value  string `yaml:"-" json:"value"`
 }
 
 type Config struct {

--- a/chromatic/match.go
+++ b/chromatic/match.go
@@ -1,0 +1,39 @@
+// Copyright 2018 Josh Komoroske. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE.txt file.
+
+package chromatic
+
+import (
+	"strings"
+)
+
+func Match(actual Page, targetTitle string, targetURL string, targetCookie cookieConfig) bool {
+	// If all conditions are blank, nothing will ever match.
+	if targetTitle == "" && targetURL == "" && targetCookie == (cookieConfig{}) {
+		return false
+	}
+
+	if targetTitle != "" {
+		if !strings.Contains(actual.Title, targetTitle) {
+			return false
+		}
+	}
+
+	if targetURL != "" {
+		if !strings.Contains(actual.URL, targetURL) {
+			return false
+		}
+	}
+
+	if targetCookie != (cookieConfig{}) {
+		for _, cookie := range actual.Cookies {
+			if cookie.Name == targetCookie.Name && cookie.Domain == targetCookie.Domain {
+				return true
+			}
+		}
+		return false
+	}
+
+	return true
+}

--- a/chromatic/match_test.go
+++ b/chromatic/match_test.go
@@ -1,0 +1,90 @@
+package chromatic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mafredri/cdp/protocol/network"
+)
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		page     Page
+		title    string
+		url      string
+		cookie   cookieConfig
+		expected bool
+	}{
+		{
+			name: "No page, no target, no match",
+		},
+		{
+			name:     "Title target match",
+			page:     Page{Title: "example | login page"},
+			title:    "login",
+			expected: true,
+		},
+		{
+			name:  "Title target no match",
+			page:  Page{Title: "example | sign up page"},
+			title: "login",
+		},
+		{
+			name:     "URL target match",
+			page:     Page{URL: "example.com/login.html"},
+			url:      "login",
+			expected: true,
+		},
+		{
+			name: "URL target no match",
+			page: Page{URL: "example.com/sign-up.html"},
+			url:  "login",
+		},
+
+		{
+			name: "Cookie target matches",
+			page: Page{Cookies: []network.Cookie{
+				{Name: "SESSIONID", Domain: "example.com"},
+			}},
+			cookie: cookieConfig{
+				Name: "SESSIONID", Domain: "example.com",
+			},
+			expected: true,
+		},
+		{
+			name: "Cookie target matches one of many",
+			page: Page{Cookies: []network.Cookie{
+				{Name: "JSESSIONID", Domain: "example.com"},
+				{Name: "SESSIONID", Domain: "example.com"},
+				{Name: "PHP_SESSION_ID", Domain: "example.com"},
+			}},
+			cookie: cookieConfig{
+				Name: "SESSIONID", Domain: "example.com",
+			},
+			expected: true,
+		},
+		{
+			name: "Cookie target doesn't match",
+			page: Page{Cookies: []network.Cookie{
+				{Name: "JSESSIONID", Domain: "example.com"},
+				{Name: "PHP_SESSION_ID", Domain: "example.com"},
+			}},
+			cookie: cookieConfig{
+				Name: "SESSIONID", Domain: "example.com",
+			},
+		},
+	}
+
+	for index, test := range tests {
+		name := fmt.Sprintf("Case #%d %s", index+1, test.name)
+		t.Run(name, func(t *testing.T) {
+			actual := Match(test.page, test.title, test.url, test.cookie)
+
+			if actual != test.expected {
+				panic(fmt.Sprintf("Expected %v, actual %v", test.expected, actual))
+			}
+		})
+
+	}
+}

--- a/chromatic/output.go
+++ b/chromatic/output.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Josh Komoroske. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE.txt file.
+
+package chromatic
+
+import (
+	"encoding/json"
+)
+
+type output struct {
+	URL     string         `json:"url"`
+	Title   string         `json:"title"`
+	Cookies []cookieConfig `json:"cookies,omitempty"`
+}
+
+func Report(result Page) (string, error) {
+	var o = output{
+		URL:     result.URL,
+		Title:   result.Title,
+		Cookies: make([]cookieConfig, len(result.Cookies)),
+	}
+
+	for index, cookie := range result.Cookies {
+		o.Cookies[index] = cookieConfig{
+			cookie.Name,
+			cookie.Domain,
+			cookie.Value,
+		}
+	}
+
+	data, err := json.MarshalIndent(o, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}

--- a/chromatic/run.go
+++ b/chromatic/run.go
@@ -49,7 +49,6 @@ func RunWithConfig(config *Config) error {
 	// Subscribe to load event stream
 	eventChan, errChan, err := client.Events()
 	if err != nil {
-		//panic(err)
 		return err
 	}
 
@@ -57,16 +56,17 @@ func RunWithConfig(config *Config) error {
 	for {
 		select {
 		case <-timedCtx.Done():
-			fmt.Printf("Timeout expired.\n")
 			return errors.New("ran out of time")
 
 		case err := <-errChan:
-			fmt.Printf("Runtime error.\n")
 			return err
 
 		case page := <-eventChan:
-			fmt.Printf("Page loaded.\n")
-			fmt.Printf("  %s (%s)\n", page.Title, page.URL)
+			if Match(page, config.End.Title, config.End.URL, config.End.Cookie) {
+				output, _ := Report(page)
+				fmt.Println(output)
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Configuration file can specify target conditions that are matched against loaded pages. If a page has a matching title, url, or cookie, report consumable information about that page and exit.